### PR TITLE
修复thinking模型的<think></think>标签内容与范围问题

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -96,6 +96,8 @@ function generateCursorBody(messages, modelName) {
 
 function chunkToUtf8String(chunk) {
   const results = []
+  const thinkingResults = []
+  const contentResults = []
   const errorResults = { hasError: false, errorMessage: '' }
   let isThinking = false;
   const buffer = Buffer.from(chunk, 'hex');
@@ -113,12 +115,14 @@ function chunkToUtf8String(chunk) {
         const response = $root.StreamUnifiedChatWithToolsResponse.decode(gunzipData);
         const thinking = response?.message?.thinking?.content
         if (thinking !== undefined && thinking.length > 0){
-            results.push(thinking);
+            thinkingResults.push(thinking);
+            // console.log('[DEBUG] 收到 thinking:', thinking);
             isThinking = true;
         }
         const content = response?.message?.content
         if (content !== undefined && content.length > 0){
-          results.push(content)
+          contentResults.push(content)
+          // console.log('[DEBUG] 收到 content:', content);
         }
       }
       else if (magicNumber == 2 || magicNumber == 3) { 
@@ -154,7 +158,12 @@ function chunkToUtf8String(chunk) {
     return { error: errorResults.errorMessage };
   }
 
-  return {isThink: isThinking, content: results.join('')};
+  // 分别返回thinking和content内容
+  return {
+    isThink: isThinking, 
+    thinkingContent: thinkingResults.join(''),
+    content: contentResults.join('')
+  };
 }
 
 function generateHashed64Hex(input, salt = '') {


### PR DESCRIPTION
# 主要改动
**utils.js 改进：**
1.完全分离了 thinking 和 content 的数据流
- 新增了专用的 thinkingResults 数组存储思考内容
- 将 contentResults 数组专门用于存储回复内容

2.返回结构改进
- 返回三个关键字段：isThink, thinkingContent, content
- 彻底分离思考内容和回复内容

**v1.js 改进：**
1.流式输出处理：
- 添加了状态标记管理：
- hasWrittenThinkingStart - 是否已输出思考开始标签
- hasWrittenThinkingEnd - 是否已输出思考结束标签
- 思考内容累积机制：累积所有思考片段，避免标签重复
- 严格控制标签输出时机：只在必要时输出开始/结束标签
- 确保在输出回复内容前先关闭思考标签

2.非流式输出处理：
- 同样分别累积思考内容和回复内容
- 在最终组装响应时，将思考内容正确封装在标签中

# 核心改进原则
- 内容分离：彻底分离思考与回复的数据流处理
- 状态管理：使用清晰的状态标记控制标签行为
- 标签控制：确保标签只出现一次，且正确嵌套
- 累积处理：分开累积思考内容和回复内容，防止混合