### PR TITLE
[fix]重构聊天响应处理逻辑，更新思考内容的变量名为reasoning_content，移除多余的思考状态标记，简化代码结构。

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -99,7 +99,6 @@ function chunkToUtf8String(chunk) {
   const thinkingResults = []
   const contentResults = []
   const errorResults = { hasError: false, errorMessage: '' }
-  let isThinking = false;
   const buffer = Buffer.from(chunk, 'hex');
   //console.log("Chunk buffer:", buffer.toString('hex'))
 
@@ -117,7 +116,6 @@ function chunkToUtf8String(chunk) {
         if (thinking !== undefined && thinking.length > 0){
             thinkingResults.push(thinking);
             // console.log('[DEBUG] 收到 thinking:', thinking);
-            isThinking = true;
         }
         const content = response?.message?.content
         if (content !== undefined && content.length > 0){
@@ -160,8 +158,7 @@ function chunkToUtf8String(chunk) {
 
   // 分别返回thinking和content内容
   return {
-    isThink: isThinking, 
-    thinkingContent: thinkingResults.join(''),
+    reasoning_content: thinkingResults.join(''),
     content: contentResults.join('')
   };
 }


### PR DESCRIPTION
删除了多余的状态标记，改为使用deepseek的reasoning_content格式。
经过测试酒馆可以用，无需开启推理内容格式化即可显示思维链
cherryStudio流式正常，非流不显示思维链，预计是其软件bug，因此代码中保留了非流显示的代码，可自行开启
此方法代码更为精简，并且适配更多格式，不必要求思维链前不得有任何内容

感谢类脑Qi@gzzhongqi提供的思路